### PR TITLE
에러 메세지 출력

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,9 @@ icon.png
 # ctags
 tags
 .tags
+
+# Vim swap file
+*.swp
+
+# byebug history
+.byebug_history

--- a/lib/naver_map.rb
+++ b/lib/naver_map.rb
@@ -38,17 +38,23 @@ class NaverMap
   def query(url, *params)
     request_to_naver(url, params)
   rescue RestClient::ExceptionWithResponse => err
-    err.response.body
+    err.response
   end
 
-  def get_result(body)
-    JSON.parse(body, symbolize_names: true)[:result]
+  def render_json(body)
+    JSON.parse(body, symbolize_names: true)
   end
 
   def extract_result(content, result_type)
-    result = get_result(content)[:items]
+    result_json  = render_json(content)
 
-    return result.first[result_type] unless result.size > 1
-    result.map { |element| element[result_type] }
+    if result_json[:result]
+      result_items = result_json[:result][:items]
+
+      return result_items.first[result_type] unless result_items.size > 1
+      result_items.map { |item| item[result_type] }
+    else
+      result_json
+    end
   end
 end

--- a/test/naver_map_test.rb
+++ b/test/naver_map_test.rb
@@ -15,17 +15,27 @@ class TestNaverMap < Minitest::Test
   end
 
   def test_coordinates_to_address
-    assert_equal "경기도 성남시 분당구 정자동 257-1",
-                 @naver_map.coordinates_to_address("127.1141382", "37.3599968"),
+    assert_equal '경기도 성남시 분당구 정자동 257-1',
+                 @naver_map.coordinates_to_address('127.1141382', '37.3599968'),
                  'The address has to be string'
   end
 
   def test_return_array_on_multiple_value
     # TODO: Find another example for address_to_coordinates method.
-    expected_result = ["경기도 성남시 분당구 정자동 178-1",
-                       "경기도 성남시 분당구 불정로 6 그린팩토리"]
+    expected_result = ['경기도 성남시 분당구 정자동 178-1',
+                       '경기도 성남시 분당구 불정로 6 그린팩토리']
     assert_equal expected_result,
-                 @naver_map.coordinates_to_address("127.1052133", "37.3595316"),
-                 "The results should be array if it has more than one item"
+                 @naver_map.coordinates_to_address('127.1052133', '37.3595316'),
+                 'The results should be array if it has more than one item'
+  end
+
+  def test_print_errors
+    wrong_input = @naver_map.address_to_coordinates('경기도 코엑스')
+    assert wrong_input.keys == [:errorMessage, :errorCode]
+  end
+
+  def test_raising_unknown_error
+    # TODO: Introduce appropriate conditions raising error
+    skip
   end
 end


### PR DESCRIPTION
- 테스트 케이스 추가 (에러 메세지 출력)
  - 에러 메세지들은 모두 `:errorMessage` , `:errorCode` 를 키로 가지고 있다는 것을 전제
  - API 키가 잘못 된 경우에도 테스트는 통과하겠지만 이를 명확하게 구분해 줄 별개의 케이스 작성 필요
- 에러 발생 시 메세지 출력
  - 정상적인 응답만 `:result` 키를 가지고 있다는 데 착안하여 조건 설정
- 변수명 변경 등의 마이너 리팩터링
  - 메서드의 이름에서 역할을 더 명확하게 유추할 수 있도록 수정
  - 메서드 실행 직후에 `[]` 메서드 사용을 지양 (따로 변수 설정 후 `[]` 메서드 사용)

제가 `rest-client` gem 을 제대로 이해 안하고 코드를 짜다보니 에러 핸들링에 조금 애를 먹었네요
404 에러 등의 에러가 수반된 응답이 오면 자동적으로 예외처리를 하는거였군요

그래서 `query` 메서드에서 정상 응답 (200 등) 이외의 응답이 오면 `rescue` 로 넘어가고 그 응답을 처리하는 거였습니다

나머지는 조건에 맞게 해당 결과를 출력해주도록 조금 수정을 가한 정도입니다

혹시 네이버 서버 측의 오류로 에러메세지조차 제대로 오지 않을 때 처리를 어떻게 할지 고민하면서
테스트 케이스를 임의로 넣어놨는데.. 당장은 필요없겠습니다